### PR TITLE
Potential issue in examples/common/imgui/imgui_widgets.cpp: Unchecked return from initialization function

### DIFF
--- a/examples/common/imgui/imgui_widgets.cpp
+++ b/examples/common/imgui/imgui_widgets.cpp
@@ -1193,7 +1193,7 @@ bool ImGui::SplitterBehavior(const ImRect& bb, ImGuiID id, ImGuiAxis axis, float
     if (!item_add)
         return false;
 
-    bool hovered, held;
+    bool hovered = false, held = false;
     ImRect bb_interact = bb;
     bb_interact.Expand(axis == ImGuiAxis_Y ? ImVec2(0.0f, hover_extend) : ImVec2(hover_extend, 0.0f));
     ButtonBehavior(bb_interact, id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

**1 instance** of this defect were found in the following locations:

---
**Instance 1**
File : `examples/common/imgui/imgui_widgets.cpp` 
Enclosing Function : `SplitterBehavior@ImGui`
Function : `ButtonBehavior@ImGui` 
https://github.com/sagpant/nanort/blob/135a452385a2903592db7518fbb80479d99ab9c3/examples/common/imgui/imgui_widgets.cpp#L1199
**Issue in**: _held, hovered_

**Code extract**:

```cpp
    bool hovered, held;
    ImRect bb_interact = bb;
    bb_interact.Expand(axis == ImGuiAxis_Y ? ImVec2(0.0f, hover_extend) : ImVec2(hover_extend, 0.0f));
    ButtonBehavior(bb_interact, id, &hovered, &held, ImGuiButtonFlags_FlattenChildren | ImGuiButtonFlags_AllowItemOverlap); <------ HERE
    if (g.ActiveId != id)
        SetItemAllowOverlap();
```

**How can I fix it?** 
Fix provided in corresponding Pull Request.
